### PR TITLE
Allow expressing dependencies

### DIFF
--- a/data/Debian.yaml
+++ b/data/Debian.yaml
@@ -1,5 +1,6 @@
 ---
 dehydrated::apache_user: 'www-data'
 dehydrated::bin: '/home/dehydrated/dehydrated'
+dehydrated::dependencies: ['curl']
 dehydrated::etcdir: '/home/dehydrated'
 dehydrated::package: ~

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -14,4 +14,6 @@ class dehydrated::config {
     group  => $dehydrated::user,
     mode   => '0755',
   }
+
+  ensure_packages($dehydrated::dependencies, { ensure => 'present' })
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,6 +6,8 @@ class dehydrated (
   Optional[String]            $package,
   String                      $user,
 
+  Array[String]               $dependencies = [],
+
   Boolean                     $apache_integration = false,
   Boolean                     $cron_integration   = false,
 

--- a/metadata.json
+++ b/metadata.json
@@ -23,8 +23,8 @@
     {
       "operatingsystem": "FreeBSD",
       "operatingsystemrelease": [
-        "10.0-STABLE",
-        "11.0-STABLE"
+        "10",
+        "11"
       ]
     }
   ],

--- a/spec/classes/dehydrated_spec.rb
+++ b/spec/classes/dehydrated_spec.rb
@@ -17,6 +17,8 @@ describe 'dehydrated' do
       it { is_expected.to compile.with_all_deps }
 
       case facts[:osfamily]
+      when 'Debian'
+        it { is_expected.to contain_package('curl').with(ensure: 'present') }
       when 'FreeBSD'
       it do
         is_expected.to contain_file('/usr/local/etc/dehydrated/config').without_content(/^PRIVATE_KEY_RENEW=/)

--- a/spec/classes/dehydrated_spec.rb
+++ b/spec/classes/dehydrated_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'dehydrated' do
-  on_supported_os(supported_os: ['FreeBSD']).each do |os, facts|
+  on_supported_os.each do |os, facts|
     context "on #{os}" do
       let(:facts) { facts }
 
@@ -16,6 +16,8 @@ describe 'dehydrated' do
 
       it { is_expected.to compile.with_all_deps }
 
+      case facts[:osfamily]
+      when 'FreeBSD'
       it do
         is_expected.to contain_file('/usr/local/etc/dehydrated/config').without_content(/^PRIVATE_KEY_RENEW=/)
       end
@@ -35,6 +37,7 @@ describe 'dehydrated' do
             is_expected.to contain_file('/usr/local/etc/dehydrated/config').with_content(/^PRIVATE_KEY_RENEW='no'$/)
           end
         end
+      end
       end
     end
   end

--- a/spec/classes/dehydrated_spec.rb
+++ b/spec/classes/dehydrated_spec.rb
@@ -7,7 +7,7 @@ describe 'dehydrated' do
 
       let(:params) do
         {
-          'contact_email' => 'bob@example.com',
+          'contact_email'     => 'bob@example.com',
           'private_key_renew' => private_key_renew,
         }
       end
@@ -22,7 +22,7 @@ describe 'dehydrated' do
         is_expected.to contain_file('/usr/local/etc/dehydrated/config').without_content(/^PRIVATE_KEY_RENEW=/)
       end
 
-      context('with XXX set') do
+      context('private_key_renew') do
         context('true') do
           let(:private_key_renew) { true }
 


### PR DESCRIPTION
When installing from the dehydrated repository, curl(1) must be
installed explicitly.  Allow setting dependencies in the module, and
add curl as our first one on Debian.