### PR TITLE
Default to dehydrated 0.5.0 when installing from repos

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Allow end-user to customize dehydrated source when using a repo,
 - Allow end-user to customize dehydrated version when using a repo,
+- Default to the latests dehydrated release (v0.5.0) when using repo.
 
 ## [2.0.0]
 ### Added

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- Allow end-user to customize dehydrated source when using a repo,
+- Allow end-user to customize dehydrated version when using a repo,
+
 ## [2.0.0]
 ### Added
 - `$dehydrated::ipversion` parameter,

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -2,4 +2,4 @@
 dehydrated::user: 'dehydrated'
 dehydrated::group: 'dehydrated'
 dehydrated::repo_source: 'https://github.com/lukas2511/dehydrated.git'
-dehydrated::repo_revision: 'v0.4.0'
+dehydrated::repo_revision: 'v0.5.0'

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,3 +1,5 @@
 ---
 dehydrated::user: 'dehydrated'
 dehydrated::group: 'dehydrated'
+dehydrated::repo_source: 'https://github.com/lukas2511/dehydrated.git'
+dehydrated::repo_revision: 'v0.4.0'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,6 +5,8 @@ class dehydrated (
   String                      $group,
   Optional[String]            $package,
   String                      $user,
+  String                      $repo_source,
+  String                      $repo_revision,
 
   Array[String]               $dependencies = [],
 

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -4,8 +4,8 @@ class dehydrated::repo {
   vcsrepo { $dehydrated::etcdir:
     ensure   => present,
     provider => 'git',
-    source   => 'https://github.com/lukas2511/dehydrated.git',
-    revision => 'v0.4.0',
+    source   => $dehydrated::repo_source,
+    revision => $dehydrated::repo_revision,
     user     => $dehydrated::user,
   }
 }


### PR DESCRIPTION
[dehydrated-0.5.0](https://github.com/lukas2511/dehydrated/releases/tag/v0.5.0) was released a few days ago, with a bunch of improvements.

Improve a bit the way a repository and revision are picked so that end-users are able to use the dehydrated version they want (even custom ones).  This will also allow them to follow upstream faster than we release a new version of this module.