### PR TITLE
Make internal classes private

### DIFF
--- a/manifests/changed.pp
+++ b/manifests/changed.pp
@@ -1,6 +1,6 @@
 # @summary Trigger a refresh of the certificates
 class dehydrated::changed {
-  include dehydrated
+  assert_private()
 
   exec { "${dehydrated::bin} --accept-terms -c":
     refreshonly => true,

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,6 +1,6 @@
 # @summary Manage dehydrated configuration
 class dehydrated::config {
-  include dehydrated
+  assert_private()
 
   file { "${dehydrated::etcdir}/config":
     ensure  => present,

--- a/manifests/cron.pp
+++ b/manifests/cron.pp
@@ -1,6 +1,6 @@
 # @summary Manage cron task to refresh certificates
 class dehydrated::cron {
-  include dehydrated
+  assert_private()
 
   if $dehydrated::cron_integration {
     $ensure = 'present'

--- a/manifests/domains.pp
+++ b/manifests/domains.pp
@@ -1,6 +1,6 @@
 # @summary Manage the domains.txt file
 class dehydrated::domains {
-  include dehydrated
+  assert_private()
 
   concat { "${dehydrated::etcdir}/domains.txt":
     ensure => present,

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -1,6 +1,6 @@
 # @summary Manage the dehydrated package
 class dehydrated::package {
-  include dehydrated
+  assert_private()
 
   package { $dehydrated::package:
     ensure => installed,

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -1,6 +1,6 @@
 # @summary Manage the dehydrated code
 class dehydrated::repo {
-  include dehydrated
+  assert_private()
 
   vcsrepo { $dehydrated::etcdir:
     ensure   => present,

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -1,6 +1,6 @@
 # @summary Manage the dehydrated user
 class dehydrated::user {
-  include dehydrated
+  assert_private()
 
   user { $dehydrated::user:
     ensure     => present,


### PR DESCRIPTION
Raise an excpetion when an internal class is used in a manifest
instead of auto-loading dehydrated.