### PR TITLE
Implement helper functions to retrieve ssl paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,3 +191,57 @@ Class used to describe the certificates that should be maintained.
 ##### Parameters (all optional)
 
 * `domains`: Specifies the list of domains to include as SAN (Subject Alternative Names).
+
+### Functions
+
+#### Function: `dehydrated::ssl_cert_file`
+
+Function used to provide the `ssl_cert_file` path.
+
+##### Required parameters
+
+* `hostname`: Hostname
+
+#### Function: `dehydrated::ssl_privkey_file`
+
+Function used to provide the `ssl_privkey_file` path.
+
+##### Required parameters
+
+* `hostname`: Hostname
+
+#### Function: `dehydrated::ssl_chain_file`
+
+Function used to provide the `ssl_chain_file` path.
+
+##### Required parameters
+
+* `hostname`: Hostname
+
+#### Function: `dehydrated::ssl_fullchain_file`
+
+Function used to provide the `ssl_fullchain_file` path.
+
+##### Required parameters
+
+* `hostname`: Hostname
+
+#### Function: `dehydrated::apache::vhost_attributes`
+
+Function used to provide the SSL attributes for `apache::vhost` defined type.
+It returns a hash with `ssl_cert`, `ssl_key` and `ssl_chain` keys.
+
+This function is designed to be used as hash attributes using splat operator, ie.:
+
+```puppet
+apache::vhost { $hostname:
+  port => 443,
+  ssl  => true,
+  [...]
+  *    => dehydrated::apache::vhost_attributes($hostname)
+}
+```
+
+##### Required parameters
+
+* `hostname`: Hostname

--- a/functions/apache/vhost_attributes.pp
+++ b/functions/apache/vhost_attributes.pp
@@ -1,0 +1,6 @@
+function dehydrated::apache::vhost_attributes($hostname) {
+  {
+    'ssl_cert'  => dehydrated::ssl_fullchain_file($hostname),
+    'ssl_key'   => dehydrated::ssl_privkey_file($hostname),
+  }
+}

--- a/functions/apache/vhost_attributes.pp
+++ b/functions/apache/vhost_attributes.pp
@@ -1,4 +1,15 @@
-function dehydrated::apache::vhost_attributes($hostname) {
+# Return the apache::vhost SSL configuration for a host
+# @param hostname The name of the host to consider
+# @return [Hash[String,String]] Virtual host configuration for the host
+#
+# @example
+#   apache::vhost { $hostname:
+#     port => 443,
+#     ssl  => true,
+  #   [...]
+#     *    => dehydrated::apache::vhost_attributes($hostname)
+#   }
+function dehydrated::apache::vhost_attributes(String $hostname) {
   {
     'ssl_cert'  => dehydrated::ssl_fullchain_file($hostname),
     'ssl_key'   => dehydrated::ssl_privkey_file($hostname),

--- a/functions/certsdir.pp
+++ b/functions/certsdir.pp
@@ -1,3 +1,5 @@
+# Return the root directory of dehydrated certificates
+# @return [String] The directory of dehydrated certificates
 function dehydrated::certsdir() {
   "${dehydrated::etcdir}/certs"
 }

--- a/functions/certsdir.pp
+++ b/functions/certsdir.pp
@@ -1,0 +1,3 @@
+function dehydrated::certsdir() {
+  "${dehydrated::etcdir}/certs"
+}

--- a/functions/ssl_cert_file.pp
+++ b/functions/ssl_cert_file.pp
@@ -1,0 +1,4 @@
+function dehydrated::ssl_cert_file($hostname) {
+  $certsdir = dehydrated::certsdir()
+  $ssl_cert_file  = "${certsdir}/${hostname}/cert.pem"
+}

--- a/functions/ssl_cert_file.pp
+++ b/functions/ssl_cert_file.pp
@@ -1,4 +1,7 @@
-function dehydrated::ssl_cert_file($hostname) {
+# Return the full path to a certificate file
+# @param hostname The name of the host to consider
+# @return [String] The path of the cerificate file
+function dehydrated::ssl_cert_file(String $hostname) {
   $certsdir = dehydrated::certsdir()
   $ssl_cert_file  = "${certsdir}/${hostname}/cert.pem"
 }

--- a/functions/ssl_chain_file.pp
+++ b/functions/ssl_chain_file.pp
@@ -1,4 +1,7 @@
-function dehydrated::ssl_chain_file($hostname) {
+# Return the full path to a certificate chain file
+# @param hostname The name of the host to consider
+# @return [String] The path of the cerificate chain file
+function dehydrated::ssl_chain_file(String $hostname) {
   $certsdir = dehydrated::certsdir()
   $ssl_chain_file  = "${certsdir}/${hostname}/chain.pem"
 }

--- a/functions/ssl_chain_file.pp
+++ b/functions/ssl_chain_file.pp
@@ -1,0 +1,4 @@
+function dehydrated::ssl_chain_file($hostname) {
+  $certsdir = dehydrated::certsdir()
+  $ssl_chain_file  = "${certsdir}/${hostname}/chain.pem"
+}

--- a/functions/ssl_fullchain_file.pp
+++ b/functions/ssl_fullchain_file.pp
@@ -1,0 +1,7 @@
+# Return the full path to a certificate fullchain file
+# @param hostname The name of the host to consider
+# @return [String] The path of the cerificate fullchain file
+function dehydrated::ssl_fullchain_file(String $hostname) {
+  $certsdir = dehydrated::certsdir()
+  $ssl_chain_file  = "${certsdir}/${hostname}/fullchain.pem"
+}

--- a/functions/ssl_privkey_file.pp
+++ b/functions/ssl_privkey_file.pp
@@ -1,0 +1,4 @@
+function dehydrated::ssl_privkey_file($hostname) {
+  $certsdir = dehydrated::certsdir()
+  $ssl_privkey_file  = "${certsdir}/${hostname}/privkey.pem"
+}

--- a/functions/ssl_privkey_file.pp
+++ b/functions/ssl_privkey_file.pp
@@ -1,4 +1,7 @@
-function dehydrated::ssl_privkey_file($hostname) {
+# Return the full path to a private key file
+# @param hostname The name of the host to consider
+# @return [String] The path of the private key file
+function dehydrated::ssl_privkey_file(String $hostname) {
   $certsdir = dehydrated::certsdir()
   $ssl_privkey_file  = "${certsdir}/${hostname}/privkey.pem"
 }

--- a/plans/renew.pp
+++ b/plans/renew.pp
@@ -1,3 +1,5 @@
+# Renew certificates about to expire
+# @param targets Target fifor certificates renewal
 plan dehydrated::renew (
   TargetSpec $targets,
 ) {

--- a/spec/functions/apache_vhost_attributes_spec.rb
+++ b/spec/functions/apache_vhost_attributes_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+describe 'dehydrated::apache::vhost_attributes' do
+  let(:facts) do
+    {
+      os: {
+        family: 'Debian',
+      },
+    }
+  end
+
+  context 'on Debian' do
+    let(:pre_condition) do
+      <<~PUPPET
+        class { 'dehydrated':
+          contact_email => 'dummy@example.com',
+        }
+      PUPPET
+    end
+    it do
+      is_expected.to run.with_params('hostname.example.com').and_return(
+        {
+          'ssl_cert' => '/home/dehydrated/certs/hostname.example.com/fullchain.pem',
+          'ssl_key'  => '/home/dehydrated/certs/hostname.example.com/privkey.pem',
+        },
+      )
+    end
+  end
+
+  context 'with custom etcdir' do
+    let(:pre_condition) do
+      <<~PUPPET
+        class { 'dehydrated':
+          contact_email => 'dummy@example.com',
+          etcdir        => '/custom/etcdir',
+        }
+      PUPPET
+    end
+    it do
+      is_expected.to run.with_params('hostname.example.com').and_return(
+        {
+          'ssl_cert' => '/custom/etcdir/certs/hostname.example.com/fullchain.pem',
+          'ssl_key'  => '/custom/etcdir/certs/hostname.example.com/privkey.pem',
+        },
+      )
+    end
+  end
+end


### PR DESCRIPTION
Mainly designed to target `apache::vhost` ssl attributes, these helper functions have been split to be used in various context (mail, nginx, etc.).