### PR TITLE
Restore the previous dehydrated repository URL

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -35,7 +35,7 @@ class dehydrated (
 
   String                      $group         = 'dehydrated',
   String                      $user          = 'dehydrated',
-  String                      $repo_source   = 'https://github.com/dehydrated-io/dehydrated.git',
+  String                      $repo_source   = 'https://github.com/lukas2511/dehydrated.git',
   String                      $repo_revision = 'v0.7.0',
 
   Array[String]               $dependencies = [],


### PR DESCRIPTION
We switched to the updated URL in cda01c0d but this requires a manual intervention on the vcsrepo side, so it's a major change.

Revert to the old URL so that we can build a backward compatible release with the updated tag.