### PR TITLE
Update the dehydrated repository URL

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -35,7 +35,7 @@ class dehydrated (
 
   String                      $group         = 'dehydrated',
   String                      $user          = 'dehydrated',
-  String                      $repo_source   = 'https://github.com/lukas2511/dehydrated.git',
+  String                      $repo_source   = 'https://github.com/dehydrated-io/dehydrated.git',
   String                      $repo_revision = 'v0.7.0',
 
   Array[String]               $dependencies = [],


### PR DESCRIPTION
The repository has been moved to an organization some time ago.  Use
this new URL instad of the old one.

This is a breaking change: the vcsrepo module will consider that the
existing repository is different, and forcing it does not seems to be a
good idea.