### PR TITLE
Remove explicit data_provider from metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -17,7 +17,6 @@
       "version_requirement": ">= 4.13.1 < 5.0.0"
     }
   ],
-  "data_provider": "hiera",
   "operatingsystem_support": [
     {
       "operatingsystem": "Debian",


### PR DESCRIPTION
The provider is inferred by the presence if the hiera.yaml file, and
data_provider has been deprecated with Puppet 5.

This fix a warning in the PuppetServer log.