### PR TITLE
Tag private classes @api private

### DIFF
--- a/manifests/changed.pp
+++ b/manifests/changed.pp
@@ -1,4 +1,6 @@
 # @summary Trigger a refresh of the certificates
+#
+# @api private
 class dehydrated::changed {
   assert_private()
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,4 +1,6 @@
 # @summary Manage dehydrated configuration
+#
+# @api private
 class dehydrated::config {
   assert_private()
 

--- a/manifests/cron.pp
+++ b/manifests/cron.pp
@@ -1,4 +1,6 @@
 # @summary Manage cron task to refresh certificates
+#
+# @api private
 class dehydrated::cron {
   assert_private()
 

--- a/manifests/domains.pp
+++ b/manifests/domains.pp
@@ -1,4 +1,6 @@
 # @summary Manage the domains.txt file
+#
+# @api private
 class dehydrated::domains {
   assert_private()
 

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -1,4 +1,6 @@
 # @summary Manage the dehydrated package
+#
+# @api private
 class dehydrated::package {
   assert_private()
 

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -1,4 +1,6 @@
 # @summary Manage the dehydrated code
+#
+# @api private
 class dehydrated::repo {
   assert_private()
 

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -1,4 +1,6 @@
 # @summary Manage the dehydrated user
+#
+# @api private
 class dehydrated::user {
   assert_private()
 


### PR DESCRIPTION
When generating REFERENCE.md, they will not appear as public class with
no parameters anymore.
