### PR TITLE
Return a hash of removed certificates in the `dehydrated::cleanup` task

### DIFF
--- a/tasks/cleanup.rb
+++ b/tasks/cleanup.rb
@@ -32,7 +32,7 @@ class OldCertificatesCleaner < TaskHelper
       res << File.basename(directory)
     end
 
-    res
+    { removed: res }
   end
 end
 


### PR DESCRIPTION
The ruby_task_helper does not serialize Array to JSON, the current
output of the module is therefore handled as plain text resulting in the
following result:

```json
{"_output":"[]\n"}
```

Build a hash of the removed certificate names to match tasks
expectations:

```json
{"removed":[]}
```
