### PR TITLE
Drop legacy parameters

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -66,8 +66,6 @@ The following parameters are available in the `dehydrated` class:
 * [`cron_integration`](#-dehydrated--cron_integration)
 * [`ip_version`](#-dehydrated--ip_version)
 * [`ca`](#-dehydrated--ca)
-* [`ca_terms`](#-dehydrated--ca_terms)
-* [`license`](#-dehydrated--license)
 * [`challengetype`](#-dehydrated--challengetype)
 * [`keysize`](#-dehydrated--keysize)
 * [`openssl_cnf`](#-dehydrated--openssl_cnf)
@@ -174,22 +172,6 @@ Default value: `undef`
 Data type: `Optional[Stdlib::Httpurl]`
 
 Path to certificate authority.
-
-Default value: `undef`
-
-##### <a name="-dehydrated--ca_terms"></a>`ca_terms`
-
-Data type: `Optional[Stdlib::Httpurl]`
-
-Path to certificate authority license terms redirect.
-
-Default value: `undef`
-
-##### <a name="-dehydrated--license"></a>`license`
-
-Data type: `Optional[String]`
-
-Path to license agreement.
 
 Default value: `undef`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,8 +13,6 @@
 # @param cron_integration Setup cron to automatically renew certificates.
 # @param ip_version Use only this IP version for name resolution.
 # @param ca Path to certificate authority.
-# @param ca_terms Path to certificate authority license terms redirect.
-# @param license Path to license agreement.
 # @param challengetype Challenge type to be used.
 # @param keysize Default keysize for private keys.
 # @param openssl_cnf Path to openssl config file.
@@ -45,8 +43,6 @@ class dehydrated (
 
   Optional[Variant[Integer[4,4],Integer[6,6]]]     $ip_version           = undef,
   Optional[Stdlib::Httpurl]                        $ca                   = undef,
-  Optional[Stdlib::Httpurl]                        $ca_terms             = undef,
-  Optional[String]                                 $license              = undef,
   Optional[Enum['http-01', 'dns-01']]              $challengetype        = undef,
   Optional[Integer[0]]                             $keysize              = undef,
   Optional[String]                                 $openssl_cnf          = undef,

--- a/templates/config.epp
+++ b/templates/config.epp
@@ -6,12 +6,6 @@ IP_VERSION=<%= String($dehydrated::ip_version, '%p') %>
 <% unless $dehydrated::ca =~ Undef { -%>
 CA=<%= String($dehydrated::ca, '%p') %>
 <% } -%>
-<% unless $dehydrated::ca_terms =~ Undef { -%>
-CA_TERMS=<%= String($dehydrated::ca_terms, '%p') %>
-<% } -%>
-<% unless $dehydrated::license =~ Undef { -%>
-LICENSE=<%= String($dehydrated::license, '%p') %>
-<% } -%>
 <% unless $dehydrated::challengetype =~ Undef { -%>
 CHALLENGETYPE=<%= String($dehydrated::challengetype, '%p') %>
 <% } -%>


### PR DESCRIPTION
These parameters do not exist anymore in dehydrated.  Remove them from
the module.
