### PR TITLE
Add support for Ubuntu

### DIFF
--- a/data/Debian/Ubuntu/18.04.yaml
+++ b/data/Debian/Ubuntu/18.04.yaml
@@ -1,0 +1,2 @@
+---
+dehydrated::dependencies: ['bsdmainutils', 'curl']

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -4,6 +4,8 @@ defaults:
   datadir: 'data'
   data_hash: 'yaml_data'
 hierarchy:
+  - name: 'Operating System'
+    path: '%{facts.os.family}/%{facts.os.name}/%{facts.os.release.major}.yaml'
   - name: 'Operating System Family'
     path: '%{facts.os.family}.yaml'
   - name: 'common'

--- a/metadata.json
+++ b/metadata.json
@@ -40,6 +40,15 @@
         "14",
         "15"
       ]
+    },
+    {
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": [
+        "18.04",
+        "20.04",
+        "22.04",
+        "24.04"
+      ]
     }
   ],
   "requirements": [

--- a/spec/setup_acceptance_node.pp
+++ b/spec/setup_acceptance_node.pp
@@ -1,0 +1,4 @@
+# Recent linux distro do not package cron by default
+package { 'cron':
+  ensure => installed,
+}


### PR DESCRIPTION
Actualy unbreak 18.04 as hexdump used to be in bsdmainutils before being
moved to bsdextrautils.
