### PR TITLE
Rework the way certificates renewal is managed

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,4 +5,5 @@ fixtures:
     concat: https://github.com/puppetlabs/puppetlabs-concat.git
     cron_core: https://github.com/puppetlabs/puppetlabs-cron_core.git
     stdlib: https://github.com/puppetlabs/puppetlabs-stdlib.git
+    systemd: https://github.com/voxpupuli/puppet-systemd.git
     vcsrepo: https://github.com/puppetlabs/puppetlabs-vcsrepo.git

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -19,6 +19,7 @@
 * `dehydrated::domains`: Manage the domains.txt file
 * `dehydrated::package`: Manage the dehydrated package
 * `dehydrated::repo`: Manage the dehydrated code
+* `dehydrated::systemd`: Manage a system timer to refresh certificates
 * `dehydrated::user`: Manage the dehydrated user
 
 ### Defined types
@@ -63,7 +64,8 @@ The following parameters are available in the `dehydrated` class:
 * [`repo_revision`](#-dehydrated--repo_revision)
 * [`dependencies`](#-dehydrated--dependencies)
 * [`apache_integration`](#-dehydrated--apache_integration)
-* [`cron_integration`](#-dehydrated--cron_integration)
+* [`renewal_provider`](#-dehydrated--renewal_provider)
+* [`renewal_interval`](#-dehydrated--renewal_interval)
 * [`dehydrated_user`](#-dehydrated--dehydrated_user)
 * [`dehydrated_group`](#-dehydrated--dehydrated_group)
 * [`ip_version`](#-dehydrated--ip_version)
@@ -175,13 +177,21 @@ Setup apache to serve the generated challenges.
 
 Default value: `false`
 
-##### <a name="-dehydrated--cron_integration"></a>`cron_integration`
+##### <a name="-dehydrated--renewal_provider"></a>`renewal_provider`
 
-Data type: `Boolean`
+Data type: `Enum['cron','systemd','none']`
 
-Setup cron to automatically renew certificates.
+Which provider should trigger certificat renewal attempts.
 
-Default value: `false`
+Default value: `'none'`
+
+##### <a name="-dehydrated--renewal_interval"></a>`renewal_interval`
+
+Data type: `Enum['never','daily','weekly']`
+
+How long to wait between certificate renewal attempts.
+
+Default value: `'daily'`
 
 ##### <a name="-dehydrated--dehydrated_user"></a>`dehydrated_user`
 

--- a/manifests/cron.pp
+++ b/manifests/cron.pp
@@ -4,19 +4,24 @@
 class dehydrated::cron {
   assert_private()
 
-  if $dehydrated::cron_integration {
-    $ensure = 'present'
-  } else {
-    $ensure = 'absent'
-  }
+  $supported_renewal_intervals = [
+    'daily',
+    'weekly',
+  ]
 
   case $facts['os']['family'] {
     'Debian', 'RedHat': {
-      cron { 'weekly_letsencrypt':
-        ensure => absent,
+      cron { 'daily_dehydrated':
+        ensure  => bool2str($dehydrated::renewal_interval == 'daily', 'present', 'absent'),
+        command => "${dehydrated::bin} --accept-terms --cron --keep-going",
+        user    => $dehydrated::user,
+        weekday => '*',
+        hour    => 3,
+        minute  => 30,
       }
+
       cron { 'weekly_dehydrated':
-        ensure  => $ensure,
+        ensure  => bool2str($dehydrated::renewal_interval == 'weekly', 'present', 'absent'),
         command => "${dehydrated::bin} --accept-terms --cron --keep-going",
         user    => $dehydrated::user,
         weekday => 0,
@@ -25,17 +30,19 @@ class dehydrated::cron {
       }
     }
     'FreeBSD': {
-      file_line { 'weekly_dehydrated_enable':
-        ensure => $ensure,
-        path   => '/etc/periodic.conf',
-        line   => 'weekly_dehydrated_enable="YES"',
-        match  => '^weekly_(letsencrypt|dehydrated)_enable=',
-      }
-      file_line { 'weekly_dehydrated_user':
-        ensure => $ensure,
-        path   => '/etc/periodic.conf',
-        line   => "weekly_dehydrated_user=\"${dehydrated::user}\"",
-        match  => '^weekly_(letsencrypt|dehydrated)_user=',
+      $supported_renewal_intervals.each |$interval| {
+        file_line { "${interval}_dehydrated_enable":
+          ensure => bool2str($interval == $dehydrated::renewal_interval, 'present', 'absent'),
+          path   => '/etc/periodic.conf',
+          line   => "${interval}_dehydrated_enable=\"YES\"",
+          match  => "^${interval}_dehydrated_enable=",
+        }
+        file_line { "${interval}_dehydrated_user":
+          ensure => bool2str($interval == $dehydrated::renewal_interval, 'present', 'absent'),
+          path   => '/etc/periodic.conf',
+          line   => "${interval}_dehydrated_user=\"${dehydrated::user}\"",
+          match  => "^${interval}_dehydrated_user=",
+        }
       }
     }
     default: {

--- a/manifests/systemd.pp
+++ b/manifests/systemd.pp
@@ -1,0 +1,14 @@
+# @summary Manage a system timer to refresh certificates
+#
+# @api private
+class dehydrated::systemd {
+  assert_private()
+
+  systemd::timer { 'dehydrated.timer':
+    ensure          => bool2str($dehydrated::renewal_interval != 'never', 'present', 'absent'),
+    active          => true,
+    enable          => true,
+    timer_content   => epp('dehydrated/systemd.timer.epp'),
+    service_content => epp('dehydrated/systemd.service.epp'),
+  }
+}

--- a/spec/classes/cron_spec.rb
+++ b/spec/classes/cron_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'dehydrated::cron' do
+  let(:pre_condition) do
+    <<~PP
+      class { 'dehydrated':
+        contact_email    => 'dummy@example.com',
+        renewal_provider => 'cron',
+      }
+    PP
+  end
+
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) { facts }
+
+      it { is_expected.to compile.with_all_deps }
+
+      if facts[:os]['family'] == 'Debian'
+        it { is_expected.to contain_cron('daily_dehydrated') }
+        it { is_expected.to contain_cron('weekly_dehydrated') }
+      end
+    end
+  end
+end

--- a/spec/classes/systemd_spec.rb
+++ b/spec/classes/systemd_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'dehydrated::systemd' do
+  let(:pre_condition) do
+    <<~PP
+      class { 'dehydrated':
+        contact_email    => 'dummy@example.com',
+        renewal_provider => 'systemd',
+      }
+    PP
+  end
+
+  on_supported_os.each do |os, facts|
+    next unless facts[:os]['family'] == 'Debian'
+
+    context "on #{os}" do
+      let(:facts) { facts }
+
+      it { is_expected.to compile.with_all_deps }
+
+      it { is_expected.to contain_systemd__timer('dehydrated.timer') }
+    end
+  end
+end

--- a/templates/systemd.service.epp
+++ b/templates/systemd.service.epp
@@ -1,0 +1,10 @@
+# Managed by Puppet, DO NOT EDIT
+
+[Unit]
+Description=Renew dehydrated certificates about to expire
+
+[Service]
+Type=oneshot
+ExecStart=<%= $dehydrated::bin %> --accept-terms --cron --keep-going
+User=<%= $dehydrated::user %>
+Group=<%= $dehydrated::user %>

--- a/templates/systemd.timer.epp
+++ b/templates/systemd.timer.epp
@@ -1,0 +1,11 @@
+# Managed by Puppet, DO NOT EDIT
+
+[Unit]
+Description=Trigger dehydrated certificates renewal
+
+[Timer]
+OnCalendar=<%= $dehydrated::renewal_interval %>
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Some linux distributions do not ship cron by default anymore.  The module unconditionally manage cron entries, resulting in catalog application failures on these operating systems until cron is installed.

To avoid this hard dependency, allow to choose how certificates renewal is te be handled with the new `dehydrated::renewal_provider` parameter which replate the `dehydrated::cron_integration` parameter.

If you previously set `cron_integration => true`, you must remove this parameter and replace it with `renewal_provider => 'cron'`.  If you prefer to rely on systemd to renew certificates, you can set `renewal_provider` accordingly.

We also introduce another new parameter `renewal_interval` which allows to select how ofter certificate renewals are attempted.  Because the world is moving toward short-lived certificates, the default internal is `daily`, but can be set to `weekly` to match the previous behavior. Also note that the default value `never` is suppored and allows to switch from one provider to another without leftovers from the legacy provider.  For this a two-step upgrade is required:

1. Keep `renewal_provider` unchanged and set `renewal_interval => 'never'`, apply a catalog;
2. Change `renewal_provider` to the new provider and set `renewal_interval` to the expected value.
