### PR TITLE
Fix hexdump package for Debian 10

### DIFF
--- a/data/Debian/Debian/10.yaml
+++ b/data/Debian/Debian/10.yaml
@@ -1,0 +1,2 @@
+---
+dehydrated::dependencies: ['bsdmainutils', 'curl']


### PR DESCRIPTION
Debian 10 had hexdump(1) packaged in bsdmainutils.
