### PR TITLE
Parameterize and harden `dehydrated::renew` Bolt task 

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -671,6 +671,14 @@ Renew certificates about to expire
 
 **Supports noop?** false
 
+#### Parameters
+
+##### `dehydrated_bin`
+
+Data type: `Optional[Stdlib::AbsolutePath]`
+
+Full path to the dehydrated binary. If unset, the task looks up dehydrated on PATH and falls back to well-known install locations.
+
 ## Plans
 
 ### <a name="dehydrated--renew"></a>`dehydrated::renew`

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -587,7 +587,7 @@ Return the full path to a certificate file
 
 Return the full path to a certificate file
 
-Returns: `String` The path of the cerificate file
+Returns: `String` The path of the certificate file
 
 ##### `hostname`
 
@@ -605,7 +605,7 @@ Return the full path to a certificate chain file
 
 Return the full path to a certificate chain file
 
-Returns: `String` The path of the cerificate chain file
+Returns: `String` The path of the certificate chain file
 
 ##### `hostname`
 
@@ -623,7 +623,7 @@ Return the full path to a certificate fullchain file
 
 Return the full path to a certificate fullchain file
 
-Returns: `String` The path of the cerificate fullchain file
+Returns: `String` The path of the certificate fullchain file
 
 ##### `hostname`
 

--- a/functions/certsdir.pp
+++ b/functions/certsdir.pp
@@ -1,5 +1,5 @@
 # Return the root directory of dehydrated certificates
 # @return [String] The directory of dehydrated certificates
-function dehydrated::certsdir() {
+function dehydrated::certsdir() >> String {
   "${dehydrated::etcdir}/certs"
 }

--- a/functions/ssl_cert_file.pp
+++ b/functions/ssl_cert_file.pp
@@ -1,7 +1,6 @@
 # Return the full path to a certificate file
 # @param hostname The name of the host to consider
-# @return [String] The path of the cerificate file
-function dehydrated::ssl_cert_file(String $hostname) {
-  $certsdir = dehydrated::certsdir()
-  $ssl_cert_file  = "${certsdir}/${hostname}/cert.pem"
+# @return [String] The path of the certificate file
+function dehydrated::ssl_cert_file(String $hostname) >> String {
+  "${dehydrated::certsdir()}/${hostname}/cert.pem"
 }

--- a/functions/ssl_chain_file.pp
+++ b/functions/ssl_chain_file.pp
@@ -1,7 +1,6 @@
 # Return the full path to a certificate chain file
 # @param hostname The name of the host to consider
-# @return [String] The path of the cerificate chain file
-function dehydrated::ssl_chain_file(String $hostname) {
-  $certsdir = dehydrated::certsdir()
-  $ssl_chain_file  = "${certsdir}/${hostname}/chain.pem"
+# @return [String] The path of the certificate chain file
+function dehydrated::ssl_chain_file(String $hostname) >> String {
+  "${dehydrated::certsdir()}/${hostname}/chain.pem"
 }

--- a/functions/ssl_fullchain_file.pp
+++ b/functions/ssl_fullchain_file.pp
@@ -1,7 +1,6 @@
 # Return the full path to a certificate fullchain file
 # @param hostname The name of the host to consider
-# @return [String] The path of the cerificate fullchain file
-function dehydrated::ssl_fullchain_file(String $hostname) {
-  $certsdir = dehydrated::certsdir()
-  $ssl_chain_file  = "${certsdir}/${hostname}/fullchain.pem"
+# @return [String] The path of the certificate fullchain file
+function dehydrated::ssl_fullchain_file(String $hostname) >> String {
+  "${dehydrated::certsdir()}/${hostname}/fullchain.pem"
 }

--- a/functions/ssl_privkey_file.pp
+++ b/functions/ssl_privkey_file.pp
@@ -1,7 +1,6 @@
 # Return the full path to a private key file
 # @param hostname The name of the host to consider
 # @return [String] The path of the private key file
-function dehydrated::ssl_privkey_file(String $hostname) {
-  $certsdir = dehydrated::certsdir()
-  $ssl_privkey_file  = "${certsdir}/${hostname}/privkey.pem"
+function dehydrated::ssl_privkey_file(String $hostname) >> String {
+  "${dehydrated::certsdir()}/${hostname}/privkey.pem"
 }

--- a/tasks/renew.json
+++ b/tasks/renew.json
@@ -1,3 +1,9 @@
 {
-  "description": "Renew certificates about to expire"
+  "description": "Renew certificates about to expire",
+  "parameters": {
+    "dehydrated_bin": {
+      "description": "Full path to the dehydrated binary. If unset, the task looks up dehydrated on PATH and falls back to well-known install locations.",
+      "type": "Optional[Stdlib::AbsolutePath]"
+    }
+  }
 }

--- a/tasks/renew.sh
+++ b/tasks/renew.sh
@@ -2,13 +2,15 @@
 
 set -e
 
-if [ -x /home/dehydrated/dehydrated ]; then
+if [ -n "$PT_dehydrated_bin" ]; then
+  dehydrated=$PT_dehydrated_bin
+elif dehydrated=$(command -v dehydrated 2>/dev/null) && [ -n "$dehydrated" ]; then
+  :
+elif [ -x /home/dehydrated/dehydrated ]; then
   dehydrated=/home/dehydrated/dehydrated
-elif [ -x /usr/local/bin/dehydrated ]; then
-  dehydrated=/usr/local/bin/dehydrated
 else
   echo "dehydrated(1) was not found on the system" >&2
   exit 1
 fi
 
-"$dehydrated" -c
+"$dehydrated" --accept-terms --cron


### PR DESCRIPTION
Accept an optional dehydrated_bin task parameter, fall back to a PATH lookup before the existing hardcoded probes, and always pass --accept-terms so the task works on freshly provisioned hosts. Switch
-c to --cron to use the same long-option style as the cron and systemd entry points.

Declaring dehydrated_bin in renew.json is required for Bolt to pass the value through as PT_dehydrated_bin.

Also include: #87 