### PR TITLE
Simplify ssl_*_file helper functions

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -587,7 +587,7 @@ Return the full path to a certificate file
 
 Return the full path to a certificate file
 
-Returns: `String` The path of the cerificate file
+Returns: `String` The path of the certificate file
 
 ##### `hostname`
 
@@ -605,7 +605,7 @@ Return the full path to a certificate chain file
 
 Return the full path to a certificate chain file
 
-Returns: `String` The path of the cerificate chain file
+Returns: `String` The path of the certificate chain file
 
 ##### `hostname`
 
@@ -623,7 +623,7 @@ Return the full path to a certificate fullchain file
 
 Return the full path to a certificate fullchain file
 
-Returns: `String` The path of the cerificate fullchain file
+Returns: `String` The path of the certificate fullchain file
 
 ##### `hostname`
 

--- a/functions/certsdir.pp
+++ b/functions/certsdir.pp
@@ -1,5 +1,5 @@
 # Return the root directory of dehydrated certificates
 # @return [String] The directory of dehydrated certificates
-function dehydrated::certsdir() {
+function dehydrated::certsdir() >> String {
   "${dehydrated::etcdir}/certs"
 }

--- a/functions/ssl_cert_file.pp
+++ b/functions/ssl_cert_file.pp
@@ -1,7 +1,6 @@
 # Return the full path to a certificate file
 # @param hostname The name of the host to consider
-# @return [String] The path of the cerificate file
-function dehydrated::ssl_cert_file(String $hostname) {
-  $certsdir = dehydrated::certsdir()
-  $ssl_cert_file  = "${certsdir}/${hostname}/cert.pem"
+# @return [String] The path of the certificate file
+function dehydrated::ssl_cert_file(String $hostname) >> String {
+  "${dehydrated::certsdir()}/${hostname}/cert.pem"
 }

--- a/functions/ssl_chain_file.pp
+++ b/functions/ssl_chain_file.pp
@@ -1,7 +1,6 @@
 # Return the full path to a certificate chain file
 # @param hostname The name of the host to consider
-# @return [String] The path of the cerificate chain file
-function dehydrated::ssl_chain_file(String $hostname) {
-  $certsdir = dehydrated::certsdir()
-  $ssl_chain_file  = "${certsdir}/${hostname}/chain.pem"
+# @return [String] The path of the certificate chain file
+function dehydrated::ssl_chain_file(String $hostname) >> String {
+  "${dehydrated::certsdir()}/${hostname}/chain.pem"
 }

--- a/functions/ssl_fullchain_file.pp
+++ b/functions/ssl_fullchain_file.pp
@@ -1,7 +1,6 @@
 # Return the full path to a certificate fullchain file
 # @param hostname The name of the host to consider
-# @return [String] The path of the cerificate fullchain file
-function dehydrated::ssl_fullchain_file(String $hostname) {
-  $certsdir = dehydrated::certsdir()
-  $ssl_chain_file  = "${certsdir}/${hostname}/fullchain.pem"
+# @return [String] The path of the certificate fullchain file
+function dehydrated::ssl_fullchain_file(String $hostname) >> String {
+  "${dehydrated::certsdir()}/${hostname}/fullchain.pem"
 }

--- a/functions/ssl_privkey_file.pp
+++ b/functions/ssl_privkey_file.pp
@@ -1,7 +1,6 @@
 # Return the full path to a private key file
 # @param hostname The name of the host to consider
 # @return [String] The path of the private key file
-function dehydrated::ssl_privkey_file(String $hostname) {
-  $certsdir = dehydrated::certsdir()
-  $ssl_privkey_file  = "${certsdir}/${hostname}/privkey.pem"
+function dehydrated::ssl_privkey_file(String $hostname) >> String {
+  "${dehydrated::certsdir()}/${hostname}/privkey.pem"
 }


### PR DESCRIPTION
Collapse each function to its return expression, declare the explicit
`>> String` return type, and drop the temporary variables (one of which
was named after a different function). Also fix the "cerificate" typo in the `@return docstrings`.

No behaviour change: the assignment form was already returning the correct value by accident, because Puppet takes the last expression as the function result.
